### PR TITLE
fix: Use portable shebang line

### DIFF
--- a/hooks/elisp-byte-compile.sh
+++ b/hooks/elisp-byte-compile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Author: James Cherti
 # URL: https://github.com/jamescherti/pre-commit-elisp

--- a/hooks/elisp-check-parens.sh
+++ b/hooks/elisp-check-parens.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Author: James Cherti
 # URL: https://github.com/jamescherti/pre-commit-elisp

--- a/hooks/elisp-check-parens.sh
+++ b/hooks/elisp-check-parens.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#!/bin/bash
 #
 # Author: James Cherti
 # URL: https://github.com/jamescherti/pre-commit-elisp

--- a/hooks/elisp-indent.sh
+++ b/hooks/elisp-indent.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Author: James Cherti
 # URL: https://github.com/jamescherti/pre-commit-elisp


### PR DESCRIPTION
Not everybody has `/bin/bash`, but a *lot* of systems have `/usr/bin/env`.